### PR TITLE
feat(node12) Add Node 12 support

### DIFF
--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -1,0 +1,45 @@
+name: Build and test Docker multiplatform images
+on:
+  push:
+    branches:
+      - '**'
+      - '!master'
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ['10.16', '12.22', '14.13', '14.15', '16.17']
+        platform: ['linux/amd64', 'linux/arm64']
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: "{{defaultContext}}:${{ matrix.image }}"
+          platforms: "${{ matrix.platform }}"
+          load: true
+          tags: somosyampi/docker-nodejs:${{ matrix.image }}-test
+      -
+        name: Test image
+        run: |
+          docker image inspect somosyampi/docker-nodejs:${{ matrix.image }}-test
+          docker run --rm somosyampi/docker-nodejs:${{ matrix.image }}-test node --version
+          docker run --rm somosyampi/docker-nodejs:${{ matrix.image }}-test npm --version
+          docker run --rm somosyampi/docker-nodejs:${{ matrix.image }}-test yarn --version
+      -
+        name: Scan for vulnerabilities
+        uses: crazy-max/ghaction-container-scan@v2
+        with:
+          image: somosyampi/docker-nodejs:${{ matrix.image }}-test
+          annotations: true
+          dockerfile: ./${{ matrix.image }}/Dockerfile

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -10,11 +10,12 @@ jobs:
   docker-description:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Update Docker Hub Description
-        uses: peter-evans/dockerhub-description@v2
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKERHUB_REPOSITORY: somosyampi/docker-nodejs
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          repository: somosyampi/docker-php-fpm
+          short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/dockerhub-publish-buildx.yml
+++ b/.github/workflows/dockerhub-publish-buildx.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['10.16', '14.13', '14.15', '16.17']
+        image: ['10.16', '12.22', '14.13', '14.15', '16.17']
     steps:
       -
         name: Set up QEMU

--- a/12.22/Dockerfile
+++ b/12.22/Dockerfile
@@ -1,0 +1,10 @@
+ARG NODE_VERSION=12.22
+FROM node:$NODE_VERSION-slim
+
+WORKDIR /app
+
+RUN apt update && \
+    apt upgrade -y && \
+    apt clean && \
+    npm config set scripts-prepend-node-path auto && \
+    npm config set unsafe-perm true


### PR DESCRIPTION
## Description

This PR adds Node 12 images. We might use in some services.

## Context and motivation

We need to slowly bump node versions, and we're missing 12.

## How was this tested?

Locally, you can run the following commands. It will build and then test the images, by inspecting them and running `node --version` in each of them. Or you can check the [Github Actions job](https://github.com/somosyampi/docker-nodejs/actions/runs/3952789012/jobs/6768291139) that ran successfully on the last commit.

Build

```sh
docker build -t somosyampi/docker-nodejs:12.22 12.22
```

Test

```sh
docker image inspect somosyampi/docker-nodejs:12.22

docker run --rm somosyampi/docker-nodejs:12.22 node --version
docker run --rm somosyampi/docker-nodejs:12.22 npm --version
docker run --rm somosyampi/docker-nodejs:12.22 yarn --version
```