### PR TITLE
feat(Node18) Add Node 18 support

### DIFF
--- a/.github/workflows/dockerhub-publish-buildx.yml
+++ b/.github/workflows/dockerhub-publish-buildx.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['10.16', '14.13', '14.15', '16.17']
+        image: ['10.16', '14.13', '14.15', '16.17', '18.14']
     steps:
       -
         name: Set up QEMU

--- a/18.14/Dockerfile
+++ b/18.14/Dockerfile
@@ -1,0 +1,10 @@
+ARG NODE_VERSION=18.14
+FROM node:$NODE_VERSION-slim
+
+WORKDIR /app
+
+RUN apt update && \
+    apt upgrade -y && \
+    apt clean && \
+    npm config set scripts-prepend-node-path auto && \
+    npm config set unsafe-perm true

--- a/18.14/Dockerfile
+++ b/18.14/Dockerfile
@@ -5,6 +5,4 @@ WORKDIR /app
 
 RUN apt update && \
     apt upgrade -y && \
-    apt clean && \
-    npm config set scripts-prepend-node-path auto && \
-    npm config set unsafe-perm true
+    apt clean


### PR DESCRIPTION
## Description

This PR adds Node 18 images. We might use in some services.

## Context and motivation

It's the latest LTS.

## How was this tested?

Locally, you can run the following commands. It will build and then test the images, by inspecting them and running `node --version` in each of them. Or you can check the [Github Actions job](https://github.com/somosyampi/docker-nodejs/actions/runs/4064059929/jobs/6997035452) that ran successfully on the last commit.

Build

```sh
docker build -t somosyampi/docker-nodejs:18.14 18.14
```

Test

```sh
docker image inspect somosyampi/docker-nodejs:18.14

docker run --rm somosyampi/docker-nodejs:18.14 node --version
docker run --rm somosyampi/docker-nodejs:18.14 npm --version
docker run --rm somosyampi/docker-nodejs:18.14 yarn --version
```

## Commands to execute when deploying

None